### PR TITLE
Prevent incrementing/decrementing out of bounds

### DIFF
--- a/src/Number/Bounded.elm
+++ b/src/Number/Bounded.elm
@@ -44,21 +44,21 @@ between a b =
 -}
 set : number -> Bounded number -> Bounded number
 set n (Bounded { min, max }) =
-    Bounded { min = min, max = max, n = Basics.max min <| Basics.min max n }
+    Bounded { min = min, max = max, n = Basics.clamp min max n }
 
 
 {-| Increments the value by the given amount, "clipping" at the max bound if it passes it.
 -}
 inc : number -> Bounded number -> Bounded number
 inc by (Bounded { min, max, n }) =
-    Bounded { min = min, max = max, n = Basics.min max <| n + by }
+    Bounded { min = min, max = max, n = Basics.clamp min max <| n + by }
 
 
 {-| Decrements the value by the given amount, "clipping" at the min bound if it passes it.
 -}
 dec : number -> Bounded number -> Bounded number
 dec by (Bounded { min, max, n }) =
-    Bounded { min = min, max = max, n = Basics.max min <| n - by }
+    Bounded { min = min, max = max, n = Basics.clamp min max <| n - by }
 
 
 {-| Transforms a Bounded value with a given function. If the value returned by the given function is greater than the max bound, it will "clip" at the max. Likewise, if the value returned by the given function is less than the min bound, it will clip at the min.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -30,16 +30,20 @@ all =
         , describe "inc"
             [ test "increments the value by the given amount" <|
                 \_ -> Expect.equal (value <| inc 2 <| set 3 <| between 1 10) 5
-            , fuzz int "the value will never increment past than the max bound" <|
+            , fuzz int "the value will never increment past the max bound" <|
                 \by ->
                     Expect.true "broke the upper bound!" <| (value <| inc by <| between 1 10) <= 10
+            , test "incrementing by a negative number doesn't break the lower bound" <|
+                \_ -> Expect.true "broke the lower bound!" <| (value <| inc -10 <| set 5 <| between 1 10) >= 1
             ]
         , describe "dec"
             [ test "decrements the value by the given amount" <|
                 \_ -> Expect.equal (value <| dec 2 <| set 5 <| between 1 10) 3
-            , fuzz int "the value will never decrement past than the min bound" <|
+            , fuzz int "the value will never decrement past the min bound" <|
                 \by ->
                     Expect.true "broke the lower bound!" <| (value <| dec by <| between 1 10) >= 1
+            , test "decrementing by a negative number doesn't break the upper bound" <|
+                \_ -> Expect.true "broke the upper bound!" <| (value <| dec -10 <| set 5 <| between 1 10) <= 10
             ]
         , describe "map"
             [ test "maps a value given a map function" <|


### PR DESCRIPTION
`inc`/`dec` didn't check for lower and upper bound violations, respectively, so passing a negative number to either could allow the bounded number's value to go out of bounds.

This prevents that by adding an upper and lower bounds check for both `inc` and `dec`, via `Basics.clamp`, and also uses `Basics.clamp` in `set`, for consistency's sake.